### PR TITLE
[BUGFIX] Use deprecated getMetaData function to ensure v9 compatibility

### DIFF
--- a/Classes/Entity/FolderItemFile.php
+++ b/Classes/Entity/FolderItemFile.php
@@ -132,7 +132,7 @@ class FolderItemFile implements \JsonSerializable
         $urlParameters = [
             'edit' => [
                 'sys_file_metadata' => [
-                    $file->getMetaData()['uid'] => 'edit',
+                    $file->_getMetaData()['uid'] => 'edit',
                 ],
             ],
             'returnUrl' => (string)$uriBuilder->buildUriFromRoute('file_DigitalAssetManagement'),

--- a/Classes/Entity/FolderItemImage.php
+++ b/Classes/Entity/FolderItemImage.php
@@ -122,7 +122,7 @@ class FolderItemImage implements \JsonSerializable
         $urlParameters = [
             'edit' => [
                 'sys_file_metadata' => [
-                    $image->getMetaData()['uid'] => 'edit',
+                    $image->_getMetaData()['uid'] => 'edit',
                 ]
             ],
             'returnUrl' => (string)$uriBuilder->buildUriFromRoute('file_DigitalAssetManagement'),


### PR DESCRIPTION
Fixes: #120

The old function contained an underscore and was deprecated in
TYPO3 CMS 10.0.0. For the cycle of v10 this will trigger a deprecation
warning, but the codebase can be run on 9.5 and 10.x.

Please see issue for more details: https://forge.typo3.org/issues/85895